### PR TITLE
inform user about pulling images

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import sphinx_rtd_theme
 project = 'dbctl'
 copyright = '2023, Mohsen Mirzakhani'
 author = 'Mohsen Mirzakhani'
-release = 'v0.4.2'
+release = 'v0.4.3'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
As DBCTL is preparing the docker images for first time running a database, user might thing cli is stuck and something went wrong. 
This change can improve ux of cli