### PR TITLE
add migration file regex filtering to Go/Python client

### DIFF
--- a/clients/dbctlgo/options.go
+++ b/clients/dbctlgo/options.go
@@ -7,8 +7,10 @@ import (
 
 // config is the client configuration.
 type config struct {
-	migrations string
-	fixtures   string
+	migrations          string
+	migrationsFileRegex string
+
+	fixtures string
 
 	// whether or not to use default migrations/fixtures loaded when dbctl started
 	withDefaultMigrations bool
@@ -77,6 +79,14 @@ func WithHost(address string, port uint32) Option {
 	return func(cfg *config) error {
 		cfg.hostAddress = address
 		cfg.hostPort = port
+		return nil
+	}
+}
+
+// WithMigrationsFileRegex configures the client to use the given regex to match what migrations file to apply.
+func WithMigrationsFileRegex(regex string) Option {
+	return func(cfg *config) error {
+		cfg.migrationsFileRegex = regex
 		return nil
 	}
 }

--- a/clients/test_sql/schema/migrations.down.sql
+++ b/clients/test_sql/schema/migrations.down.sql
@@ -1,0 +1,1 @@
+drop table foo;


### PR DESCRIPTION
Allow filtering migration files by regex pattern when creating databases. You can now specify patterns like `\.up\.sql$` to only apply specific migrations. When no pattern is passed it behaves as before.

Usage:
  Go:    WithMigrationsFileRegex(`\.up\.sql$`)
  Python: with_migrations_file_regex(r"\.up\.sql$")